### PR TITLE
chore(eth-light-client): bump deps to latest then release new version

### DIFF
--- a/contracts/eth_light_client/client_type_lock/Cargo.lock
+++ b/contracts/eth_light_client/client_type_lock/Cargo.lock
@@ -232,8 +232,8 @@ dependencies = [
 
 [[package]]
 name = "eth_light_client_in_ckb-verification"
-version = "0.2.0"
-source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?tag=v0.2.0#5574b6636303e68006c4d7953ea7aea09e2a8967"
+version = "0.2.1"
+source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?tag=v0.2.1#5e8549d20f8c91da7362cb1c87823c53fd7cd205"
 dependencies = [
  "ckb-merkle-mountain-range",
  "eth2_hashing",
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "molecule"
-version = "0.7.5"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd9767ab5e5f2ea40f71ff4c8bdb633c50509052e093c2fdd0e390a749dfa3"
+checksum = "edc8276c02a006bddad7d1c28c1a88f30421e1b5f0ba0ca96ceb8077c7d20c01"
 dependencies = [
  "cfg-if",
 ]

--- a/contracts/eth_light_client/client_type_lock/Cargo.lock
+++ b/contracts/eth_light_client/client_type_lock/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ibc-ckb_contracts-eth_light_client-client_type_lock"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake2b-rs",
  "ckb-std",

--- a/contracts/eth_light_client/client_type_lock/Cargo.toml
+++ b/contracts/eth_light_client/client_type_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibc-ckb_contracts-eth_light_client-client_type_lock"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Boyu Yang <yangby@cryptape.com>"]
 edition = "2021"
 license = "MIT"

--- a/contracts/eth_light_client/client_type_lock/Cargo.toml
+++ b/contracts/eth_light_client/client_type_lock/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/synapseweb3/ibc-ckb-contracts"
 ckb-std = "0.13.0"
 # TODO Replace blake2b-rs with ckb-hash if ckb-hash support no-std.
 blake2b-rs = "0.2.0"
-eth_light_client_in_ckb-verification = { version = "0.2.0", default-features = false, git = "https://github.com/synapseweb3/eth-light-client-in-ckb", tag = "v0.2.0" }
+eth_light_client_in_ckb-verification = { version = "0.2.1", default-features = false, git = "https://github.com/synapseweb3/eth-light-client-in-ckb", tag = "v0.2.1" }
 
 [features]
 default = []

--- a/contracts/eth_light_client/mock_business_type_lock/Cargo.lock
+++ b/contracts/eth_light_client/mock_business_type_lock/Cargo.lock
@@ -216,8 +216,8 @@ dependencies = [
 
 [[package]]
 name = "eth_light_client_in_ckb-verification"
-version = "0.2.0"
-source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?tag=v0.2.0#5574b6636303e68006c4d7953ea7aea09e2a8967"
+version = "0.2.1"
+source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?tag=v0.2.1#5e8549d20f8c91da7362cb1c87823c53fd7cd205"
 dependencies = [
  "ckb-merkle-mountain-range",
  "eth2_hashing",
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "molecule"
-version = "0.7.5"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd9767ab5e5f2ea40f71ff4c8bdb633c50509052e093c2fdd0e390a749dfa3"
+checksum = "edc8276c02a006bddad7d1c28c1a88f30421e1b5f0ba0ca96ceb8077c7d20c01"
 dependencies = [
  "cfg-if",
 ]

--- a/contracts/eth_light_client/mock_business_type_lock/Cargo.lock
+++ b/contracts/eth_light_client/mock_business_type_lock/Cargo.lock
@@ -294,7 +294,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ibc-ckb_contracts-eth_light_client-mock_business_type_lock"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ckb-std",
  "eth_light_client_in_ckb-verification",

--- a/contracts/eth_light_client/mock_business_type_lock/Cargo.toml
+++ b/contracts/eth_light_client/mock_business_type_lock/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/synapseweb3/ibc-ckb-contracts"
 
 [dependencies]
 ckb-std = "0.13.0"
-eth_light_client_in_ckb-verification = { version = "0.2.0", default-features = false, git = "https://github.com/synapseweb3/eth-light-client-in-ckb", tag = "v0.2.0" }
+eth_light_client_in_ckb-verification = { version = "0.2.1", default-features = false, git = "https://github.com/synapseweb3/eth-light-client-in-ckb", tag = "v0.2.1" }
 
 [features]
 default = []

--- a/contracts/eth_light_client/mock_business_type_lock/Cargo.toml
+++ b/contracts/eth_light_client/mock_business_type_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibc-ckb_contracts-eth_light_client-mock_business_type_lock"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Boyu Yang <yangby@cryptape.com>"]
 edition = "2021"
 license = "MIT"

--- a/contracts/eth_light_client/verify_bin/Cargo.lock
+++ b/contracts/eth_light_client/verify_bin/Cargo.lock
@@ -216,8 +216,8 @@ dependencies = [
 
 [[package]]
 name = "eth_light_client_in_ckb-verification"
-version = "0.2.0"
-source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?tag=v0.2.0#5574b6636303e68006c4d7953ea7aea09e2a8967"
+version = "0.2.1"
+source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?tag=v0.2.1#5e8549d20f8c91da7362cb1c87823c53fd7cd205"
 dependencies = [
  "ckb-merkle-mountain-range",
  "eth2_hashing",
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "molecule"
-version = "0.7.5"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd9767ab5e5f2ea40f71ff4c8bdb633c50509052e093c2fdd0e390a749dfa3"
+checksum = "edc8276c02a006bddad7d1c28c1a88f30421e1b5f0ba0ca96ceb8077c7d20c01"
 dependencies = [
  "cfg-if",
 ]

--- a/contracts/eth_light_client/verify_bin/Cargo.lock
+++ b/contracts/eth_light_client/verify_bin/Cargo.lock
@@ -294,7 +294,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ibc-ckb_contracts-eth_light_client-verify_bin"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ckb-std",
  "eth_light_client_in_ckb-verification",

--- a/contracts/eth_light_client/verify_bin/Cargo.toml
+++ b/contracts/eth_light_client/verify_bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibc-ckb_contracts-eth_light_client-verify_bin"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Boyu Yang <yangby@cryptape.com>"]
 edition = "2021"
 license = "MIT"

--- a/contracts/eth_light_client/verify_bin/Cargo.toml
+++ b/contracts/eth_light_client/verify_bin/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/synapseweb3/ibc-ckb-contracts"
 
 [dependencies]
 ckb-std = "0.13.0"
-eth_light_client_in_ckb-verification = { version = "0.2.0", default-features = false, git = "https://github.com/synapseweb3/eth-light-client-in-ckb", tag = "v0.2.0" }
+eth_light_client_in_ckb-verification = { version = "0.2.1", default-features = false, git = "https://github.com/synapseweb3/eth-light-client-in-ckb", tag = "v0.2.1" }
 
 [features]
 default = []


### PR DESCRIPTION
For synapseweb3/eth-light-client-in-ckb#6.

Both two PRs could be reverted and both two `v0.2.1` versions could be yanked, after CKB v0.110.0 released; CKB v0.110.0 is [planned to be released on 2023-06-23](https://github.com/nervosnetwork/ckb/issues/4008).