### PR TITLE
chore: update dependencies of ckb-ics repo

### DIFF
--- a/contracts/ics/axon_client/Cargo.toml
+++ b/contracts/ics/axon_client/Cargo.toml
@@ -7,14 +7,14 @@ homepage = "https://github.com/synapseweb3/ibc-ckb-contracts"
 repository = "https://github.com/synapseweb3/ibc-ckb-contracts"
 
 [dependencies]
-ckb-ics-axon = {git = "https://github.com/synapseweb3/ckb-ics.git", rev = "e57a669"}
+ckb-ics-axon = {git = "https://github.com/synapseweb3/ckb-ics.git", rev = "efd7af5"}
 axon-tools-riscv = {version = "0.1.1", features = ["proof"]}
 axon-types = {git = "https://github.com/axonweb3/axon-contract", rev = "8c2338a"}
 rlp ={ version = "0.5.2", default-features = false}
 molecule = { version = "0.7", default-features = false }
 
 [features]
-default = []
+default = ["debugging"]
 debugging = []
 
 [profile.release]

--- a/contracts/ics/chan/Cargo.lock
+++ b/contracts/ics/chan/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "ckb-ics-axon"
 version = "0.1.0"
-source = "git+https://github.com/synapseweb3/ckb-ics.git?rev=e57a669#e57a669663a4de283d92ce2f538c5cb001035f44"
+source = "git+https://github.com/synapseweb3/ckb-ics.git?rev=efd7af5#efd7af5f887626128041c3cad8552ffe8c4ead0e"
 dependencies = [
  "bytes",
  "ethereum-types",

--- a/contracts/ics/chan/Cargo.toml
+++ b/contracts/ics/chan/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/synapseweb3/ibc-ckb-contracts"
 
 [dependencies]
 ckb-std = "0.13.0"
-ckb-ics-axon = {git = "https://github.com/synapseweb3/ckb-ics.git", rev = "e57a669"}
+ckb-ics-axon = {git = "https://github.com/synapseweb3/ckb-ics.git", rev = "efd7af5"}
 rlp ={ version = "0.5.2", default-features = false}
 ckb-standalone-types ={ version = "0.1.2", default-features = false}
 tiny-keccak = {version = "2.0.2", features = ["keccak"]}

--- a/contracts/ics/conn/Cargo.lock
+++ b/contracts/ics/conn/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "ckb-ics-axon"
 version = "0.1.0"
-source = "git+https://github.com/synapseweb3/ckb-ics.git?rev=e57a669#e57a669663a4de283d92ce2f538c5cb001035f44"
+source = "git+https://github.com/synapseweb3/ckb-ics.git?rev=efd7af5#efd7af5f887626128041c3cad8552ffe8c4ead0e"
 dependencies = [
  "bytes",
  "ethereum-types",

--- a/contracts/ics/conn/Cargo.toml
+++ b/contracts/ics/conn/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/synapseweb3/ibc-ckb-contracts"
 
 [dependencies]
 ckb-std = "0.13.0"
-ckb-ics-axon = {git = "https://github.com/synapseweb3/ckb-ics.git", rev = "e57a669"}
+ckb-ics-axon = {git = "https://github.com/synapseweb3/ckb-ics.git", rev = "efd7af5"}
 rlp ={ version = "0.5.2", default-features = false}
 ckb-standalone-types ={ version = "0.1.2", default-features = false}
 tiny-keccak = {version = "2.0.2", features = ["keccak"]}

--- a/contracts/ics/packet/Cargo.lock
+++ b/contracts/ics/packet/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "ckb-ics-axon"
 version = "0.1.0"
-source = "git+https://github.com/synapseweb3/ckb-ics.git?rev=e57a669#e57a669663a4de283d92ce2f538c5cb001035f44"
+source = "git+https://github.com/synapseweb3/ckb-ics.git?rev=efd7af5#efd7af5f887626128041c3cad8552ffe8c4ead0e"
 dependencies = [
  "bytes",
  "ethereum-types",

--- a/contracts/ics/packet/Cargo.toml
+++ b/contracts/ics/packet/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/synapseweb3/ibc-ckb-contracts"
 
 [dependencies]
 ckb-std = "0.13.0"
-ckb-ics-axon = {git = "https://github.com/synapseweb3/ckb-ics.git", rev = "e57a669"}
+ckb-ics-axon = {git = "https://github.com/synapseweb3/ckb-ics.git", rev = "efd7af5"}
 rlp ={ version = "0.5.2", default-features = false}
 ckb-standalone-types ={ version = "0.1.2", default-features = false}
 tiny-keccak = {version = "2.0.2", features = ["keccak"]}


### PR DESCRIPTION
1. since I upgraded ckb-ics repo, its commit log has changed, so I should come back to ibc-ckb-contracts repo to apply this change too
2. the axon-client is not ready, so I switch this crate to debugging mode as its default feature