### PR TITLE
feat: don't generate A instructions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 target = "riscv64imac-unknown-none-elf"
+rustflags = [
+  "-C", "target-feature=-a"
+]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ defaults:
     shell: bash
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: -D warnings -C target-feature=-a
   RUST_BACKTRACE: full
   RUST_TOOLCHAIN: 1.68.2
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "atomics-polyfill"
+version = "0.1.0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "autotools"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,9 +137,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
  "serde",
 ]
@@ -524,6 +531,7 @@ dependencies = [
 name = "ibc-ckb_contracts-eth_light_client-verify_bin"
 version = "0.3.0-alpha"
 dependencies = [
+ "atomics-polyfill",
  "ckb-std",
  "eth_light_client_in_ckb-verification",
 ]
@@ -575,6 +583,7 @@ dependencies = [
 name = "ics-base"
 version = "0.1.0"
 dependencies = [
+ "atomics-polyfill",
  "ckb-ics-axon",
  "ckb-std",
  "rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/atomics-polyfill",
     "contracts/eth_light_client/client_type_lock",
     "contracts/eth_light_client/mock_business_type_lock",
     "contracts/eth_light_client/verify_bin",

--- a/contracts/eth_light_client/verify_bin/Cargo.toml
+++ b/contracts/eth_light_client/verify_bin/Cargo.toml
@@ -10,6 +10,8 @@ repository = "https://github.com/synapseweb3/ibc-ckb-contracts"
 
 [dependencies]
 ckb-std = "0.13.0"
+atomics-polyfill = { path = "../../../crates/atomics-polyfill" }
+
 [dependencies.eth_light_client_in_ckb-verification]
 version = "0.3.0-alpha"
 git = "https://github.com/synapseweb3/eth-light-client-in-ckb"

--- a/contracts/eth_light_client/verify_bin/src/main.rs
+++ b/contracts/eth_light_client/verify_bin/src/main.rs
@@ -16,6 +16,8 @@ use ckb_std::default_alloc;
 ckb_std::entry!(program_entry);
 default_alloc!();
 
+atomics_polyfill::use_atomics_polyfill!();
+
 fn program_entry() -> i8 {
     match entry::main() {
         Ok(_) => 0,

--- a/contracts/ics/base/Cargo.toml
+++ b/contracts/ics/base/Cargo.toml
@@ -11,3 +11,4 @@ ckb-std = "0.13.0"
 ckb-ics-axon = { git = "https://github.com/synapseweb3/ckb-ics.git", rev = "4e89e76d16" }
 rlp = { version = "0.5.2", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
+atomics-polyfill = { path = "../../../crates/atomics-polyfill" }

--- a/contracts/ics/base/src/lib.rs
+++ b/contracts/ics/base/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 extern crate alloc;
 
+atomics_polyfill::use_atomics_polyfill!();
+
 pub mod error;
 pub mod handler;
 pub mod utils;

--- a/crates/atomics-polyfill/Cargo.toml
+++ b/crates/atomics-polyfill/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "atomics-polyfill"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+homepage = "https://github.com/synapseweb3/ibc-ckb-contracts"
+repository = "https://github.com/synapseweb3/ibc-ckb-contracts"
+
+[lib]
+
+[build-dependencies]
+cc = "1.0.83"

--- a/crates/atomics-polyfill/README.md
+++ b/crates/atomics-polyfill/README.md
@@ -1,0 +1,1 @@
+Inspired by https://github.com/xxuejie/ckb-contract-bytes-without-a/

--- a/crates/atomics-polyfill/build.rs
+++ b/crates/atomics-polyfill/build.rs
@@ -1,0 +1,23 @@
+fn main() {
+    // let clang = match std::env::var_os("CLANG") {
+    //     Some(val) => val,
+    //     None => "clang-16".into(),
+    // };
+
+    cc::Build::new()
+        .file("src/atomics.c")
+        .static_flag(true)
+        // .compiler(clang)
+        .no_default_flags(true)
+        // .flag("--target=riscv64")
+        .flag("-march=rv64imc")
+        .flag("-O3")
+        .flag("-fvisibility=hidden")
+        .flag("-fdata-sections")
+        .flag("-ffunction-sections")
+        .flag("-Wall")
+        .flag("-Werror")
+        .flag("-Wno-unused-parameter")
+        .define("__SHARED_LIBRARY__", None)
+        .compile("atomics-polyfill");
+}

--- a/crates/atomics-polyfill/src/atomics.c
+++ b/crates/atomics-polyfill/src/atomics.c
@@ -1,0 +1,429 @@
+// https://github.com/xxuejie/lib-dummy-atomics/blob/50dc5fefb215bc93e761fb655d7a4fdade04c2d1/atomics.c
+
+// MIT License
+//
+// Copyright (c) 2023 Xuejie Xiao
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define _ATOMIC_EXCHANGE_IMPL(t)                                               \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  t old = *dst;                                                                \
+  *dst = val;                                                                  \
+  return old
+
+uint8_t __atomic_exchange_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_EXCHANGE_IMPL(uint8_t);
+}
+
+uint16_t __atomic_exchange_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_EXCHANGE_IMPL(uint16_t);
+}
+
+uint32_t __atomic_exchange_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_EXCHANGE_IMPL(uint32_t);
+}
+
+uint64_t __atomic_exchange_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_EXCHANGE_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_EXCHANGE_IMPL
+
+#define _ATOMIC_COMPARE_IMPL(t)                                                \
+  (void)weak;                                                                  \
+  (void)success_memorder;                                                      \
+  (void)failure_memorder;                                                      \
+  t *dst = (t *)ptr;                                                           \
+  t *old = (t *)expected;                                                      \
+  if (*dst == *old) {                                                          \
+    *dst = desired;                                                            \
+    return true;                                                               \
+  } else {                                                                     \
+    *old = *dst;                                                               \
+    return false;                                                              \
+  }
+
+bool __atomic_compare_exchange_1(volatile void *ptr, void *expected,
+                                 uint8_t desired, bool weak,
+                                 int success_memorder, int failure_memorder) {
+  _ATOMIC_COMPARE_IMPL(uint8_t);
+}
+
+bool __atomic_compare_exchange_2(volatile void *ptr, void *expected,
+                                 uint16_t desired, bool weak,
+                                 int success_memorder, int failure_memorder) {
+  _ATOMIC_COMPARE_IMPL(uint16_t);
+}
+
+bool __atomic_compare_exchange_4(volatile void *ptr, void *expected,
+                                 uint32_t desired, bool weak,
+                                 int success_memorder, int failure_memorder) {
+  _ATOMIC_COMPARE_IMPL(uint32_t);
+}
+
+bool __atomic_compare_exchange_8(volatile void *ptr, void *expected,
+                                 uint64_t desired, bool weak,
+                                 int success_memorder, int failure_memorder) {
+  _ATOMIC_COMPARE_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_COMPARE_IMPL
+
+#define _ATOMIC_LOAD_IMPL(t)                                                   \
+  (void)memorder;                                                              \
+  return *((t *)ptr)
+
+uint8_t __atomic_load_1(const volatile void *ptr, int memorder) {
+  _ATOMIC_LOAD_IMPL(uint8_t);
+}
+
+uint16_t __atomic_load_2(const volatile void *ptr, int memorder) {
+  _ATOMIC_LOAD_IMPL(uint16_t);
+}
+
+uint32_t __atomic_load_4(const volatile void *ptr, int memorder) {
+  _ATOMIC_LOAD_IMPL(uint32_t);
+}
+
+uint64_t __atomic_load_8(const volatile void *ptr, int memorder) {
+  _ATOMIC_LOAD_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_LOAD_IMPL
+
+#define _ATOMIC_STORE_IMPL(t)                                                  \
+  (void)memorder;                                                              \
+  *((t *)ptr) = val
+
+void __atomic_store_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_STORE_IMPL(uint8_t);
+}
+
+void __atomic_store_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_STORE_IMPL(uint16_t);
+}
+
+void __atomic_store_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_STORE_IMPL(uint32_t);
+}
+
+void __atomic_store_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_STORE_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_STORE_IMPL
+
+#define _ATOMIC_FETCH_ADD_IMPL(t)                                              \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  t old = *dst;                                                                \
+  *dst += val;                                                                 \
+  return old
+
+uint8_t __atomic_fetch_add_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_FETCH_ADD_IMPL(uint8_t);
+}
+
+uint16_t __atomic_fetch_add_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_FETCH_ADD_IMPL(uint16_t);
+}
+
+uint32_t __atomic_fetch_add_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_FETCH_ADD_IMPL(uint32_t);
+}
+
+uint64_t __atomic_fetch_add_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_FETCH_ADD_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_FETCH_ADD_IMPL
+
+#define _ATOMIC_FETCH_SUB_IMPL(t)                                              \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  t old = *dst;                                                                \
+  *dst -= val;                                                                 \
+  return old
+
+uint8_t __atomic_fetch_sub_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_FETCH_SUB_IMPL(uint8_t);
+}
+
+uint16_t __atomic_fetch_sub_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_FETCH_SUB_IMPL(uint16_t);
+}
+
+uint32_t __atomic_fetch_sub_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_FETCH_SUB_IMPL(uint32_t);
+}
+
+uint64_t __atomic_fetch_sub_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_FETCH_SUB_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_FETCH_SUB_IMPL
+
+#define _ATOMIC_FETCH_AND_IMPL(t)                                              \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  t old = *dst;                                                                \
+  *dst &= val;                                                                 \
+  return old
+
+uint8_t __atomic_fetch_and_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_FETCH_AND_IMPL(uint8_t);
+}
+
+uint16_t __atomic_fetch_and_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_FETCH_AND_IMPL(uint16_t);
+}
+
+uint32_t __atomic_fetch_and_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_FETCH_AND_IMPL(uint32_t);
+}
+
+uint64_t __atomic_fetch_and_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_FETCH_AND_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_FETCH_AND_IMPL
+
+#define _ATOMIC_FETCH_XOR_IMPL(t)                                              \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  t old = *dst;                                                                \
+  *dst ^= val;                                                                 \
+  return old
+
+uint8_t __atomic_fetch_xor_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_FETCH_XOR_IMPL(uint8_t);
+}
+
+uint16_t __atomic_fetch_xor_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_FETCH_XOR_IMPL(uint16_t);
+}
+
+uint32_t __atomic_fetch_xor_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_FETCH_XOR_IMPL(uint32_t);
+}
+
+uint64_t __atomic_fetch_xor_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_FETCH_XOR_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_FETCH_XOR_IMPL
+
+#define _ATOMIC_FETCH_OR_IMPL(t)                                               \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  t old = *dst;                                                                \
+  *dst |= val;                                                                 \
+  return old
+
+uint8_t __atomic_fetch_or_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_FETCH_OR_IMPL(uint8_t);
+}
+
+uint16_t __atomic_fetch_or_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_FETCH_OR_IMPL(uint16_t);
+}
+
+uint32_t __atomic_fetch_or_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_FETCH_OR_IMPL(uint32_t);
+}
+
+uint64_t __atomic_fetch_or_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_FETCH_OR_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_FETCH_OR_IMPL
+
+#define _ATOMIC_FETCH_NAND_IMPL(t)                                             \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  t old = *dst;                                                                \
+  *dst = ~(*dst & val);                                                        \
+  return old
+
+uint8_t __atomic_fetch_nand_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_FETCH_NAND_IMPL(uint8_t);
+}
+
+uint16_t __atomic_fetch_nand_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_FETCH_NAND_IMPL(uint16_t);
+}
+
+uint32_t __atomic_fetch_nand_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_FETCH_NAND_IMPL(uint32_t);
+}
+
+uint64_t __atomic_fetch_nand_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_FETCH_NAND_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_FETCH_NAND_IMPL
+
+#define _ATOMIC_ADD_FETCH_IMPL(t)                                              \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  *dst += val;                                                                 \
+  return *dst
+
+uint8_t __atomic_add_fetch_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_ADD_FETCH_IMPL(uint8_t);
+}
+
+uint16_t __atomic_add_fetch_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_ADD_FETCH_IMPL(uint16_t);
+}
+
+uint32_t __atomic_add_fetch_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_ADD_FETCH_IMPL(uint32_t);
+}
+
+uint64_t __atomic_add_fetch_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_ADD_FETCH_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_ADD_FETCH_IMPL
+
+#define _ATOMIC_SUB_FETCH_IMPL(t)                                              \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  *dst -= val;                                                                 \
+  return *dst
+
+uint8_t __atomic_sub_fetch_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_SUB_FETCH_IMPL(uint8_t);
+}
+
+uint16_t __atomic_sub_fetch_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_SUB_FETCH_IMPL(uint16_t);
+}
+
+uint32_t __atomic_sub_fetch_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_SUB_FETCH_IMPL(uint32_t);
+}
+
+uint64_t __atomic_sub_fetch_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_SUB_FETCH_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_SUB_FETCH_IMPL
+
+#define _ATOMIC_AND_FETCH_IMPL(t)                                              \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  *dst &= val;                                                                 \
+  return *dst
+
+uint8_t __atomic_and_fetch_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_AND_FETCH_IMPL(uint8_t);
+}
+
+uint16_t __atomic_and_fetch_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_AND_FETCH_IMPL(uint16_t);
+}
+
+uint32_t __atomic_and_fetch_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_AND_FETCH_IMPL(uint32_t);
+}
+
+uint64_t __atomic_and_fetch_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_AND_FETCH_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_AND_FETCH_IMPL
+
+#define _ATOMIC_XOR_FETCH_IMPL(t)                                              \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  *dst ^= val;                                                                 \
+  return *dst
+
+uint8_t __atomic_xor_fetch_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_XOR_FETCH_IMPL(uint8_t);
+}
+
+uint16_t __atomic_xor_fetch_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_XOR_FETCH_IMPL(uint16_t);
+}
+
+uint32_t __atomic_xor_fetch_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_XOR_FETCH_IMPL(uint32_t);
+}
+
+uint64_t __atomic_xor_fetch_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_XOR_FETCH_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_XOR_FETCH_IMPL
+
+#define _ATOMIC_OR_FETCH_IMPL(t)                                               \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  *dst |= val;                                                                 \
+  return *dst
+
+uint8_t __atomic_or_fetch_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_OR_FETCH_IMPL(uint8_t);
+}
+
+uint16_t __atomic_or_fetch_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_OR_FETCH_IMPL(uint16_t);
+}
+
+uint32_t __atomic_or_fetch_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_OR_FETCH_IMPL(uint32_t);
+}
+
+uint64_t __atomic_or_fetch_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_OR_FETCH_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_OR_FETCH_IMPL
+
+#define _ATOMIC_NAND_FETCH_IMPL(t)                                             \
+  (void)memorder;                                                              \
+  t *dst = (t *)ptr;                                                           \
+  *dst = ~((*dst) & val);                                                      \
+  return *dst
+
+uint8_t __atomic_nand_fetch_1(volatile void *ptr, uint8_t val, int memorder) {
+  _ATOMIC_NAND_FETCH_IMPL(uint8_t);
+}
+
+uint16_t __atomic_nand_fetch_2(volatile void *ptr, uint16_t val, int memorder) {
+  _ATOMIC_NAND_FETCH_IMPL(uint16_t);
+}
+
+uint32_t __atomic_nand_fetch_4(volatile void *ptr, uint32_t val, int memorder) {
+  _ATOMIC_NAND_FETCH_IMPL(uint32_t);
+}
+
+uint64_t __atomic_nand_fetch_8(volatile void *ptr, uint64_t val, int memorder) {
+  _ATOMIC_NAND_FETCH_IMPL(uint64_t);
+}
+
+#undef _ATOMIC_NAND_FETCH_IMPL

--- a/crates/atomics-polyfill/src/lib.rs
+++ b/crates/atomics-polyfill/src/lib.rs
@@ -1,0 +1,9 @@
+#![no_std]
+
+#[macro_export]
+macro_rules! use_atomics_polyfill {
+    () => {
+        #[link(name = "atomics-polyfill")]
+        extern "C" {}
+    };
+}


### PR DESCRIPTION
A instructions are only supported after ckb 2023 hardfork. It's not supported on ckb testnet or mainnet now.

So we use some compiler and linking hacks to avoid generating A instructions. See https://github.com/xxuejie/ckb-contract-bytes-without-a/ for a more detailed explanation.